### PR TITLE
feat: add pair relationship to PairDayData entity

### DIFF
--- a/src/common/hourDayUpdates.ts
+++ b/src/common/hourDayUpdates.ts
@@ -51,6 +51,7 @@ export function updatePairDayData(pair: Pair, event: ethereum.Event): PairDayDat
     pairDayData.token0 = pair.token0
     pairDayData.token1 = pair.token1
     pairDayData.pairAddress = event.address
+    pairDayData.pair = pair.id
     pairDayData.dailyVolumeToken0 = ZERO_BD
     pairDayData.dailyVolumeToken1 = ZERO_BD
     pairDayData.dailyVolumeUSD = ZERO_BD

--- a/src/v2/schema.graphql
+++ b/src/v2/schema.graphql
@@ -90,6 +90,7 @@ type Pair @entity(immutable: false) {
   liquidityProviderCount: BigInt! # used to detect new exchanges
   # derived fields
   pairHourData: [PairHourData!]! @derivedFrom(field: "pair")
+  pairDayData: [PairDayData!]! @derivedFrom(field: "pair")
   liquidityPositions: [LiquidityPosition!]! @derivedFrom(field: "pair")
   mints: [Mint!]! @derivedFrom(field: "pair")
   burns: [Burn!]! @derivedFrom(field: "pair")
@@ -242,6 +243,7 @@ type PairDayData @entity(immutable: false) {
   id: ID!
   date: Int!
   pairAddress: Bytes!
+  pair: Pair!
   token0: Token!
   token1: Token!
 


### PR DESCRIPTION
## Summary
- Add `pair: Pair!` field to `PairDayData` entity for proper GraphQL relationship
- Add `pairDayData` derived field to `Pair` entity for bidirectional navigation
- Brings `PairDayData` schema in line with `PairHourData` structure

## Problem
`PairDayData` only had `pairAddress: Bytes!` which stored the raw address but didn't create a proper GraphQL entity relationship. This made it inconsistent with `PairHourData` which had a proper `pair: Pair!` field, and limited query capabilities.

## Changes
1. Added `pair: Pair!` field to `PairDayData` (schema.graphql:246)
2. Added `pairDayData: [PairDayData!]! @derivedFrom(field: "pair")` to `Pair` entity (schema.graphql:93)

## Benefits
- Enables querying `pair.pairDayData` to get all day data for a pair
- Allows navigation from `pairDayData.pair` to access the full pair entity
- Supports GraphQL queries with nested relationships
- Maintains backward compatibility by keeping `pairAddress` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)